### PR TITLE
Add hip-hop analysis script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ An exploratory data analysis project using Microsoft Excel to uncover insights f
 
 ## 📊 Project Structure
 
-<pre><code>```markdown spotify-analysis/ ├── data/ # Raw and cleaned datasets ├── dashboards/ # Excel dashboards and visuals ├── notebooks/ # (Optional) Notes or logic in Jupyter/markdown ├── README.md # Project overview └── .gitignore ``` </code></pre>
+```text
+spotify-analysis/
+├── data/       # Raw dataset
+├── dashboards/ # Excel dashboards and visuals
+├── reports/
+├── scripts/    # Python utilities
+└── README.md
+```
+
 
 ---
 
@@ -39,6 +47,14 @@ An exploratory data analysis project using Microsoft Excel to uncover insights f
 - Which tracks are the most popular across genres?
 - How do audio features vary between genres or years?
 - What correlations exist between energy, tempo, and popularity?
+
+## 🐍 Python Analysis
+
+A small utility script is provided in `scripts/hiphop_analysis.py` to explore Hip-Hop tracks using the built-in `csv` module. It computes average audio features and lists the most popular songs. Run it with:
+
+```bash
+python scripts/hiphop_analysis.py
+```
 
 ---
 

--- a/scripts/hiphop_analysis.py
+++ b/scripts/hiphop_analysis.py
@@ -1,0 +1,57 @@
+import csv
+from statistics import mean
+
+FEATURES = [
+    "popularity",
+    "danceability",
+    "energy",
+    "tempo",
+    "valence",
+]
+
+def load_hiphop_rows(csv_path):
+    with open(csv_path, newline='', encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            # the dataset may include a BOM in the header
+            genre = row.get("genre") or row.get("\ufeffgenre")
+            if genre == "Hip-Hop":
+                yield row
+
+
+def compute_feature_means(rows):
+    stats = {f: [] for f in FEATURES}
+    for row in rows:
+        for f in FEATURES:
+            val = row.get(f)
+            if val:
+                stats[f].append(float(val))
+    return {f: round(mean(values), 2) for f, values in stats.items() if values}
+
+
+def most_popular(rows, n=5):
+    sorted_rows = sorted(rows, key=lambda r: int(r.get("popularity", 0)), reverse=True)
+    top = []
+    for r in sorted_rows[:n]:
+        track = r.get("track_name", "")
+        artist = r.get("artist_name", "")
+        pop = r.get("popularity", 0)
+        top.append(f"{track} - {artist} (Popularity: {pop})")
+    return top
+
+
+def main():
+    csv_path = "data/SpotifyFeatures.csv"
+    hiphop_rows = list(load_hiphop_rows(csv_path))
+    means = compute_feature_means(hiphop_rows)
+    print("Averages for Hip-Hop tracks:")
+    for f in FEATURES:
+        print(f, means.get(f))
+    print()
+    print("Top Hip-Hop tracks:")
+    for line in most_popular(hiphop_rows):
+        print(line)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `hiphop_analysis.py` script for calculating hip-hop track stats
- document Python analysis workflow in README
- clean up project structure section in README

## Testing
- `python scripts/hiphop_analysis.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686084ee161c832fa7f4bdd992c678d2